### PR TITLE
Adds sample Go app that does not import modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A collection of sample applications that can be built using Paketo Buildpacks.
 * [ASPNet](/dotnet-core/aspnet)
 
 ### Go
+* [No Imports](/go/no-imports)
 * [Mod](/go/mod)
 * [Dep](/go/dep)
 

--- a/go/no-imports/README.md
+++ b/go/no-imports/README.md
@@ -1,0 +1,13 @@
+# Go Sample App using no imports
+
+## Building
+
+`pack build go-sample --buildpack gcr.io/paketo-buildpacks/go`
+
+## Running
+
+`docker run --interactive --tty --env PORT=8080 --publish 8080:8080 go-sample`
+
+## Viewing
+
+`curl http://localhost:8080`

--- a/go/no-imports/main.go
+++ b/go/no-imports/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+const INDEX = `<!DOCTYPE html>
+<html>
+  <head>
+    <title>Powered By Paketo Buildpacks</title>
+  </head>
+  <body>
+    <img style="display: block; margin-left: auto; margin-right: auto; width: 50%;" src="https://paketo.io/images/paketo-logo-full-color.png"></img>
+  </body>
+</html>`
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(w, INDEX)
+	})
+
+	log.Fatal(http.ListenAndServe(":"+os.Getenv("PORT"), nil))
+}

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -50,6 +50,36 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 				Expect(os.RemoveAll(source)).To(Succeed())
 			})
 
+			context("no imports", func() {
+				it("builds successfully", func() {
+					var err error
+					source, err = occam.Source(filepath.Join("../go", "no-imports"))
+					Expect(err).NotTo(HaveOccurred())
+
+					var logs fmt.Stringer
+					image, logs, err = pack.Build.
+						WithPullPolicy("never").
+						WithBuilder(builder).
+						Execute(name, source)
+					Expect(err).ToNot(HaveOccurred(), logs.String)
+
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Distribution Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Build Buildpack")))
+
+					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Go Mod Vendor Buildpack")))
+					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Dep Buildpack")))
+					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Dep Ensure Buildpack")))
+
+					container, err = docker.Container.Run.
+						WithEnv(map[string]string{"PORT": "8080"}).
+						WithPublish("8080").
+						Execute(image.ID)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(container).Should(Serve(ContainSubstring("Powered By Paketo Buildpacks")).OnPort(8080))
+				})
+			})
+
 			context("uses go modules", func() {
 				it("builds successfully", func() {
 					var err error


### PR DESCRIPTION
- Adds a sample that does not import any modules to demonstrate that
workflow which is supported by the Go buildpack
- Adds this sample to the tests

Resolves #12

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
