### PR TITLE
Updates for new native-image usage

### DIFF
--- a/java/native-image/java-native-image-sample/README.md
+++ b/java/native-image/java-native-image-sample/README.md
@@ -2,14 +2,19 @@
 
 ## Building
 
+### With `pack`
 ```bash
 pack build applications/native-image \
   --builder paketobuildpacks/builder:tiny \
-  --env BP_BOOT_NATIVE_IMAGE=true
+  --env BP_NATIVE_IMAGE=true
+```
+
+### With the Spring Boot Maven Plugin
+```
+./mvnw -Dmaven.test.skip=true spring-boot:build-image
 ```
 
 ## Running
-
 ```bash
 docker run --rm --tty --publish 8080:8080 applications/native-image
 ```

--- a/java/native-image/java-native-image-sample/pom.xml
+++ b/java/native-image/java-native-image-sample/pom.xml
@@ -1,66 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.3</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>io.paketo</groupId>
-	<artifactId>demo</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>demo</name>
-	<description>Demo project for Spring Boot</description>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.4.3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>io.paketo</groupId>
+    <artifactId>demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>demo</name>
+    <description>Demo project for Spring Boot</description>
 
-	<properties>
-		<java.version>1.8</java.version>
-	</properties>
+    <properties>
+        <java.version>1.8</java.version>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-graalvm-native</artifactId>
-			<version>0.8.5</version>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.experimental</groupId>
+            <artifactId>spring-graalvm-native</artifactId>
+            <version>0.8.5</version>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <image>
+                        <name>applications/native-image</name>
+                        <builder>paketobuildpacks/builder:tiny</builder>
+                        <env>
+                            <BP_NATIVE_IMAGE>true</BP_NATIVE_IMAGE>
+                        </env>
+                    </image>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
-	</repositories>
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
 
 </project>

--- a/java/native-image/java_native_image_test.go
+++ b/java/native-image/java_native_image_test.go
@@ -84,7 +84,7 @@ func testJNIWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 				image, logs, err = pack.Build.
 					WithPullPolicy("never").
 					WithBuilder(builder).
-					WithEnv(map[string]string{"BP_BOOT_NATIVE_IMAGE": "true"}).
+					WithEnv(map[string]string{"BP_NATIVE_IMAGE": "true"}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -100,7 +100,7 @@ func testJNIWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Native Image Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Paketo Native Image Buildpack")))
 
 				Eventually(container).Should(Serve(ContainSubstring("UP")).OnPort(8080).WithEndpoint("/actuator/health"))
 			})


### PR DESCRIPTION
* BP_BOOT_NATIVE_IMAGE has been deprecated in favor of BP_NATIVE_IMAGE
* Paketo Spring Boot Native Image renamed to Paketo Native Image Buildpack
* Adds maven plugin usage to native image samples

This won't pass until https://github.com/paketo-buildpacks/full-builder/pull/176 merges, but https://github.com/paketo-buildpacks/full-builder/pull/176 can't merge until samples pass

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
