### PR TITLE
action/setup-java now requires distribution to be set

### DIFF
--- a/.github/workflows/java-akka.yml
+++ b/.github/workflows/java-akka.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.sbt

--- a/.github/workflows/java-application-insights.yml
+++ b/.github/workflows/java-application-insights.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.m2

--- a/.github/workflows/java-aspectj.yml
+++ b/.github/workflows/java-aspectj.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.m2

--- a/.github/workflows/java-dist-zip.yml
+++ b/.github/workflows/java-dist-zip.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/java-gradle.yml
+++ b/.github/workflows/java-gradle.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/java-kotlin.yml
+++ b/.github/workflows/java-kotlin.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/java-leiningen.yml
+++ b/.github/workflows/java-leiningen.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.lein

--- a/.github/workflows/java-maven.yml
+++ b/.github/workflows/java-maven.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.m2

--- a/.github/workflows/java-native-image.yml
+++ b/.github/workflows/java-native-image.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.m2

--- a/.github/workflows/java-war.yml
+++ b/.github/workflows/java-war.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: actions/cache@v2.1.4
         with:
           path: ~/.m2


### PR DESCRIPTION
## Summary

It appears that `actions/setup-java` now requires a distribution to be set, so it knows what JVM distribution to install. This sets the distribution to Zulu.

## Use Cases

Running actions that depend on `actions/setup-java` were failing with `Input required and not supplied: distribution`.

https://github.com/paketo-buildpacks/samples/runs/2308197921?check_suite_focus=true

## Checklist

* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [n/a] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
