### PR TITLE
Bump to use Java 11

### DIFF
--- a/.github/workflows/java-application-insights.yml
+++ b/.github/workflows/java-application-insights.yml
@@ -27,5 +27,5 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('java/application-insights/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - run: ./mvnw -B package
+      - run: ./mvnw -B package -Djava.version=${{ matrix.java }}
         working-directory: java/application-insights

--- a/.github/workflows/java-aspectj.yml
+++ b/.github/workflows/java-aspectj.yml
@@ -27,5 +27,5 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('java/aspectj/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - run: ./mvnw -B package
+      - run: ./mvnw -B package -Djava.version=${{ matrix.java }}
         working-directory: java/aspectj

--- a/.github/workflows/java-maven.yml
+++ b/.github/workflows/java-maven.yml
@@ -27,5 +27,5 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('java/maven/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - run: ./mvnw -B package
+      - run: ./mvnw -B package -Djava.version=${{ matrix.java }}
         working-directory: java/maven

--- a/.github/workflows/java-native-image.yml
+++ b/.github/workflows/java-native-image.yml
@@ -27,5 +27,5 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('java/native-image/java-native-image-sample/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - run: ./mvnw -B package
+      - run: ./mvnw -B package -Djava.version=${{ matrix.java }}
         working-directory: java/native-image/java-native-image-sample

--- a/.github/workflows/java-war.yml
+++ b/.github/workflows/java-war.yml
@@ -27,5 +27,5 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('java/war/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - run: ./mvnw -B package
+      - run: ./mvnw -B package -Djava.version=${{ matrix.java }}
         working-directory: java/war

--- a/java/application-insights/pom.xml
+++ b/java/application-insights/pom.xml
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 		<applicationinsights.version>2.6.3</applicationinsights.version>
 	</properties>
 

--- a/java/aspectj/pom.xml
+++ b/java/aspectj/pom.xml
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>

--- a/java/native-image/java-native-image-sample/pom.xml
+++ b/java/native-image/java-native-image-sample/pom.xml
@@ -15,7 +15,7 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
     </properties>
 
     <dependencies>

--- a/java/war/pom.xml
+++ b/java/war/pom.xml
@@ -16,7 +16,7 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Use Java 11 instead of Java 8

## Use Cases
It's still valid to use Java 8, but it is towards the end of its lifecycle. Java 11 has been out a while, is stable and it should be what most stable apps are using now.

This will still result in unit tests being run against both Java 8 & Java 11. It will shift to using Java 11 when running the integration tests.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
