### PR TITLE
Removes extraneous references to ca-certificates buildpack

### DIFF
--- a/ca-certificates/README.md
+++ b/ca-certificates/README.md
@@ -24,7 +24,6 @@ This sample contains a simple Golang application that will make a `HEAD` request
 Build the sample application
 ```bash
 pack build applications/ca-certificates \
-    --buildpack paketo-buildpacks/ca-certificates \
     --buildpack paketo-buildpacks/go
 ```
 Run the sample application **without** the binding, passing the URL as a positional argument, to observe the expected error (should print `ERROR: Head "<url>": x509: certificate signed by unknown authority`):
@@ -50,7 +49,6 @@ Build the sample application with the sample buildpack and set `$BP_TEST_URL` to
 ```bash
 pack build applications/ca-certificates \
     --builder paketobuildpacks/builder:full \
-    --buildpack paketo-buildpacks/ca-certificates \
     --buildpack ./buildpack \
     --buildpack paketo-buildpacks/go \
     --volume "$(pwd)/binding:/platform/bindings/ca-certificates" \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We don't need these flags as the `ca-certificates` buildpack is included in the `go` buildpack order.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
