### PR TITLE
Use one test-failure label

### DIFF
--- a/.github/workflows/test-all-samples.yml
+++ b/.github/workflows/test-all-samples.yml
@@ -49,11 +49,11 @@ jobs:
       if: ${{ failure() && github.event_name != 'pull_request' }}
       run: |
         echo "${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}" | gh auth login --with-token
-        failure_issue=$(gh issue list --json number --label "${{ matrix.suite }}-test-failure" --jq .[0].number)
+        failure_issue=$(gh issue list --json number --label "test-failure" --jq .[0].number)
         if [ -z $failure_issue ]; \
         then gh issue create \
-        --title "Failure: 'Test ${{ matrix.suite }}' workflow" \
-        --label "${{ matrix.suite }}-test-failure,test-failure" \
+        --title "Failure: 'Test All Samples (${{ matrix.suite }})' workflow" \
+        --label "test-failure" \
         --body "[Test ${{ matrix.suite }} workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) failed. Please take a look to ensure samples are working. (cc @paketo-buildpacks/content-maintainers)" \
         -R ${{github.repository}}; \
         else gh issue comment $failure_issue --body "Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"; \


### PR DESCRIPTION
instead of a different label for each language family

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
`gh issue create --label <label-name>` fails if the label doesn't already exist on the repo (as seen [here](https://github.com/paketo-buildpacks/samples/runs/6198576064?check_suite_focus=true#step:5:16)). So I've added a `test-failure` label to this repo.

This PR makes all test failures generate labels with a `test-failure` label, instead of a label prefixed with the language family name.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
