### PR TITLE
Implement RFC 0050: Rename Buildpacks

### DIFF
--- a/dotnet-core/dotnet_test.go
+++ b/dotnet-core/dotnet_test.go
@@ -94,11 +94,11 @@ func testDotnetWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(image.ID)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Core Runtime Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Core SDK Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo ICU Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Publish Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Execute Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Core Runtime")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Core SDK")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for ICU")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Publish")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Execute")))
 
 					Eventually(container).Should(BeAvailable())
 
@@ -119,12 +119,12 @@ func testDotnetWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Core Runtime Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo ASP.NET Core Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Core SDK Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo ICU Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Publish Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Execute Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Core Runtime")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for ASP.NET Core")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Core SDK")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for ICU")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Publish")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Execute")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -149,8 +149,8 @@ func testDotnetWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo ICU Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Execute Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for ICU")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Execute")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -175,8 +175,8 @@ func testDotnetWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo ICU Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Execute Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for ICU")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Execute")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -201,8 +201,8 @@ func testDotnetWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo ICU Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo .NET Execute Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for ICU")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for .NET Execute")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -105,7 +105,7 @@ func testGitWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred(), logs.String())
 
 					Expect(logs).To(ContainLines(
-						"Paketo Git Clone Buildpack",
+						"Paketo Buildpack for Git Clone",
 						"",
 						"protocol=https",
 						"host=example.com",

--- a/go/go_test.go
+++ b/go/go_test.go
@@ -88,12 +88,12 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Distribution Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Build Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Distribution")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Build")))
 
-					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Go Mod Vendor Buildpack")))
-					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Dep Buildpack")))
-					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Dep Ensure Buildpack")))
+					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Buildpack for Go Mod Vendor")))
+					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Buildpack for Dep")))
+					Expect(logs).NotTo(ContainLines(ContainSubstring("Paketo Buildpack for Dep Ensure")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -118,9 +118,9 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Distribution Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Mod Vendor Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Build Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Distribution")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Mod Vendor")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Build")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -145,10 +145,10 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Distribution Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Dep Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Dep Ensure Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Go Build Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Distribution")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Dep")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Dep Ensure")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Build")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).

--- a/java/java_test.go
+++ b/java/java_test.go
@@ -108,10 +108,10 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo SBT Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo DistZip Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for SBT")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for DistZip")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -137,11 +137,11 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Spring Boot")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -167,11 +167,11 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Spring Boot")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -204,10 +204,10 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Gradle Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo DistZip Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Gradle")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for DistZip")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -236,10 +236,10 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Gradle Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Gradle")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -263,10 +263,10 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Spring Boot")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -295,11 +295,11 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Gradle Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Gradle")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Spring Boot")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -328,10 +328,10 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Leiningen Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Leiningen")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -361,11 +361,11 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Spring Boot")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -391,10 +391,10 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Apache Tomcat Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Apache Tomcat")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -423,10 +423,10 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Clojure Tools Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Clojure Tools")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").
@@ -460,10 +460,10 @@ func testJavaWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CA Certificates Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Clojure Tools Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CA Certificates")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Clojure Tools")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
 
 					container, err = docker.Container.Run.
 						WithPublish("8080").

--- a/java/native-image/java_native_image_test.go
+++ b/java/native-image/java_native_image_test.go
@@ -99,11 +99,11 @@ func testJNIWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 
 					Eventually(container).Should(BeAvailable())
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Native Image Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Spring Boot")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Native Image")))
 
 					Eventually(container).Should(Serve(ContainSubstring("UP")).OnPort(8080).WithEndpoint("/actuator/health"))
 				})
@@ -125,10 +125,10 @@ func testJNIWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Native Image Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Native Image")))
 
 					container, err = docker.Container.Run.Execute(image.ID)
 					Expect(err).NotTo(HaveOccurred())
@@ -161,10 +161,10 @@ func testJNIWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Native Image Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Maven")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Executable JAR")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Native Image")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).

--- a/nodejs/nodejs_test.go
+++ b/nodejs/nodejs_test.go
@@ -94,8 +94,8 @@ func testNodejsWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Start Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Start")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -120,9 +120,9 @@ func testNodejsWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo NPM Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo NPM Start Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for NPM Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for NPM Start")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -147,9 +147,9 @@ func testNodejsWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Yarn Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Yarn Start Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Yarn Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Yarn Start")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -177,10 +177,10 @@ func testNodejsWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo NPM Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Run Script Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo NPM Start Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for NPM Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Run Script")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for NPM Start")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -206,10 +206,10 @@ func testNodejsWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Yarn Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Run Script Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Yarn Start Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Yarn Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Run Script")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Yarn Start")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -237,10 +237,10 @@ func testNodejsWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo NPM Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Run Script Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo NPM Start Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for NPM Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Run Script")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for NPM Start")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).

--- a/procfile/procfile_test.go
+++ b/procfile/procfile_test.go
@@ -87,7 +87,7 @@ func testProcfileWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Procfile Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Procfile")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).

--- a/python/python_test.go
+++ b/python/python_test.go
@@ -88,10 +88,10 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Miniconda Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Conda Env Update Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Python Start Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Procfile Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Miniconda")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Conda Env Update")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Python Start")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Procfile")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -116,11 +116,11 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CPython Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Pip Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Pip Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Python Start Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Procfile Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Pip")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Pip Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Python Start")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Procfile")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -145,12 +145,12 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CPython Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Pip Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Pipenv Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Pipenv Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Python Start Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Procfile Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Pip")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Pipenv")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Pipenv Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Python Start")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Procfile")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -175,12 +175,12 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CPython Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Pip Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Poetry Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Poetry Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Python Start Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Procfile Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Pip")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Poetry")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Poetry Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Python Start")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Procfile")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -205,11 +205,11 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CPython Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Pip Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Poetry Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Poetry Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Poetry Run Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Pip")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Poetry")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Poetry Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Poetry Run")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -234,9 +234,9 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo CPython Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Python Start Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Procfile Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Python Start")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Procfile")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).

--- a/ruby/ruby_test.go
+++ b/ruby/ruby_test.go
@@ -90,10 +90,10 @@ func testRubyWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo MRI Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundler Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundle Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Passenger Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for MRI")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundler")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundle Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Passenger")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -118,10 +118,10 @@ func testRubyWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo MRI Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundler Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundle Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Puma Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for MRI")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundler")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundle Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Puma")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -146,10 +146,10 @@ func testRubyWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo MRI Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundler Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundle Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Rackup Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for MRI")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundler")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundle Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Rackup")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -174,10 +174,10 @@ func testRubyWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo MRI Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundler Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundle Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Rake Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for MRI")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundler")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundle Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Rake")))
 
 					container, err = docker.Container.Run.Execute(image.ID)
 					Expect(err).NotTo(HaveOccurred())
@@ -204,10 +204,10 @@ func testRubyWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo MRI Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundler Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundle Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Thin Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for MRI")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundler")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundle Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Thin")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -232,10 +232,10 @@ func testRubyWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo MRI Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundler Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundle Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Unicorn Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for MRI")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundler")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundle Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Unicorn")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -260,14 +260,14 @@ func testRubyWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo MRI Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundler Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Bundle Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Yarn Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Yarn Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Rails Assets Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Puma Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for MRI")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundler")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Bundle Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Yarn")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Yarn Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Rails Assets")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Puma")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{

--- a/web-servers/web_servers_test.go
+++ b/web-servers/web_servers_test.go
@@ -93,7 +93,7 @@ func testHTTPDWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Apache HTTP Server Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Apache HTTP Server")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -355,7 +355,7 @@ func testNGINXWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Nginx Server Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Nginx Server")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -609,10 +609,10 @@ func testJavaScriptFrontendWithBuilder(builder string) func(*testing.T, spec.G, 
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo NPM Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Run Script Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Apache HTTP Server Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for NPM Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Run Script")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Apache HTTP Server")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).
@@ -643,10 +643,10 @@ func testJavaScriptFrontendWithBuilder(builder string) func(*testing.T, spec.G, 
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Engine Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo NPM Install Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Node Run Script Buildpack")))
-					Expect(logs).To(ContainLines(ContainSubstring("Paketo Nginx Server Buildpack")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Engine")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for NPM Install")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Node Run Script")))
+					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Nginx Server")))
 
 					container, err = docker.Container.Run.
 						WithEnv(map[string]string{"PORT": "8080"}).


### PR DESCRIPTION
Renames 'Paketo <tech> Buildpack' to 'Paketo Buildpack for <tech>' where present in README or Go code.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this project.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
