### PR TITLE
Add merge_group as a trigger

### DIFF
--- a/.github/workflows/java-akka.yml
+++ b/.github/workflows/java-akka.yml
@@ -1,5 +1,6 @@
 name: akka
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/akka/**

--- a/.github/workflows/java-application-insights.yml
+++ b/.github/workflows/java-application-insights.yml
@@ -1,5 +1,6 @@
 name: application-insights
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/application-insights/**

--- a/.github/workflows/java-aspectj.yml
+++ b/.github/workflows/java-aspectj.yml
@@ -1,5 +1,6 @@
 name: aspectj
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/aspectj/**

--- a/.github/workflows/java-dist-zip.yml
+++ b/.github/workflows/java-dist-zip.yml
@@ -1,5 +1,6 @@
 name: dist-zip
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/dist-zip/**

--- a/.github/workflows/java-gradle.yml
+++ b/.github/workflows/java-gradle.yml
@@ -1,5 +1,6 @@
 name: gradle
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/gradle/**

--- a/.github/workflows/java-kotlin.yml
+++ b/.github/workflows/java-kotlin.yml
@@ -1,5 +1,6 @@
 name: kotlin
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/kotlin/**

--- a/.github/workflows/java-leiningen.yml
+++ b/.github/workflows/java-leiningen.yml
@@ -1,5 +1,6 @@
 name: leiningen
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/leiningen/**

--- a/.github/workflows/java-maven.yml
+++ b/.github/workflows/java-maven.yml
@@ -1,5 +1,6 @@
 name: maven
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/maven/**

--- a/.github/workflows/java-native-image.yml
+++ b/.github/workflows/java-native-image.yml
@@ -1,5 +1,6 @@
 name: native-image
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/native-image/java-native-image-sample/**

--- a/.github/workflows/java-opentelemetry.yml
+++ b/.github/workflows/java-opentelemetry.yml
@@ -1,5 +1,6 @@
 name: opentelemetry
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/opentelemetry/**

--- a/.github/workflows/java-war.yml
+++ b/.github/workflows/java-war.yml
@@ -1,5 +1,6 @@
 name: war
 "on":
+  merge_group:
   pull_request:
     paths:
     - java/war/**

--- a/.github/workflows/test-all-samples.yml
+++ b/.github/workflows/test-all-samples.yml
@@ -1,6 +1,7 @@
 name: Test All Samples
 
 on:
+  merge_group:
   schedule:
   - cron: '30 1 * * *'
   workflow_dispatch: {}

--- a/.github/workflows/test-pull-request-ca-certificates.yml
+++ b/.github/workflows/test-pull-request-ca-certificates.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (ca-certificates)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-dotnet-core.yml
+++ b/.github/workflows/test-pull-request-dotnet-core.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (Dotnet Core)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-git.yml
+++ b/.github/workflows/test-pull-request-git.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (git)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-go.yml
+++ b/.github/workflows/test-pull-request-go.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (Go)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-java-native-image.yml
+++ b/.github/workflows/test-pull-request-java-native-image.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (Java Native Image)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-java.yml
+++ b/.github/workflows/test-pull-request-java.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (Java)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-nodejs.yml
+++ b/.github/workflows/test-pull-request-nodejs.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (Nodejs)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-php.yml
+++ b/.github/workflows/test-pull-request-php.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (PHP)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-procfile.yml
+++ b/.github/workflows/test-pull-request-procfile.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (Procfile)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-python.yml
+++ b/.github/workflows/test-pull-request-python.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (python)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-ruby.yml
+++ b/.github/workflows/test-pull-request-ruby.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (Ruby)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main

--- a/.github/workflows/test-pull-request-web-servers.yml
+++ b/.github/workflows/test-pull-request-web-servers.yml
@@ -1,6 +1,7 @@
 name: Test Pull Request (web-servers)
 
 on:
+  merge_group:
   pull_request:
     branches:
     - main


### PR DESCRIPTION
## Summary

This PR adds merge_group as a trigger in preparation for enabling Github Merge Queues.

## Use Cases

Enable Github Merge Queues.
