### PR TITLE
Update Ruby to 3 in Gemfiles

### DIFF
--- a/ruby/puma/Gemfile
+++ b/ruby/puma/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '~> 2.0'
+ruby '~> 3'
 
 gem 'puma'
 gem 'sinatra'

--- a/ruby/rake/Gemfile
+++ b/ruby/rake/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '~> 2.0'
+ruby '~> 3'
 
 gem 'rake'

--- a/ruby/thin/Gemfile
+++ b/ruby/thin/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '~> 2.0'
+ruby '~> 3'
 
 gem 'thin'
 gem 'sinatra'

--- a/ruby/unicorn/Gemfile
+++ b/ruby/unicorn/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '~> 2.0'
+ruby '~> 3'
 
 gem 'unicorn'
 gem 'sinatra'


### PR DESCRIPTION
## Summary

[Ruby 2 is end of support this month.](https://endoflife.date/ruby) Also, the [Jammy builder does not support Ruby 2](https://github.com/paketo-buildpacks/mri/blob/v0.11.5/buildpack.toml#L21-L45).

I therefore update the samples to Ruby 3 and tried the build run and run with the latest Jammy full builder.

## Use Cases

As a Paketo user, I want to have up-to-date Ruby samples so that I can use them with the provided builders

## Checklist

* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).