### PR TITLE
php apps: explicitly ask for full builder

### DIFF
--- a/php/app_with_extensions/README.md
+++ b/php/app_with_extensions/README.md
@@ -5,7 +5,7 @@ the `.php.ini.d` directory. It runs with the built-in PHP server.
 
 ## Building
 
-`pack build php-extension-sample --buildpack paketo-buildpacks/php`
+`pack build php-extension-sample --buildpack paketo-buildpacks/php --builder paketobuildpacks/builder-jammy-full`
 
 ## Running
 
@@ -14,3 +14,7 @@ the `.php.ini.d` directory. It runs with the built-in PHP server.
 ## Viewing
 
 `curl http://localhost:8080`
+
+## Stack Support
+
+The Paketo PHP buildpack requires the Full Jammy Stack. See [stack docs](https://paketo.io/docs/concepts/stacks) for more details

--- a/php/builtin-server/README.md
+++ b/php/builtin-server/README.md
@@ -13,7 +13,7 @@ With the Pack CLI, this would involve setting `--env BP_PHP_WEB_DIR=htdocs`.
 
 ## Building
 
-`pack build php-builtin-server-sample --buildpack paketo-buildpacks/php`
+`pack build php-builtin-server-sample --buildpack paketo-buildpacks/php  --builder paketobuildpacks/builder-jammy-full`
 
 ## Running
 
@@ -22,3 +22,7 @@ With the Pack CLI, this would involve setting `--env BP_PHP_WEB_DIR=htdocs`.
 ## Viewing
 
 `curl http://localhost:8080`
+
+## Stack Support
+
+The Paketo PHP buildpack requires the Full Jammy Stack. See [stack docs](https://paketo.io/docs/concepts/stacks) for more details

--- a/php/composer/README.md
+++ b/php/composer/README.md
@@ -6,7 +6,7 @@ the server where to find files to serve.
 
 ## Building
 
-`pack build php-composer-sample --env BP_PHP_WEB_DIR=htdocs --buildpack paketo-buildpacks/php`
+`pack build php-composer-sample --env BP_PHP_WEB_DIR=htdocs --buildpack paketo-buildpacks/php --builder paketobuildpacks/builder-jammy-full`
 
 ## Running
 
@@ -15,3 +15,7 @@ the server where to find files to serve.
 ## Viewing
 
 `curl http://localhost:8080`
+
+## Stack Support
+
+The Paketo PHP buildpack requires the Full Jammy Stack. See [stack docs](https://paketo.io/docs/concepts/stacks) for more details

--- a/php/composer_with_extensions/README.md
+++ b/php/composer_with_extensions/README.md
@@ -5,7 +5,7 @@ built-in PHP server.
 
 ## Building
 
-`pack build php-composer-extension-sample --buildpack paketo-buildpacks/php`
+`pack build php-composer-extension-sample --buildpack paketo-buildpacks/php  --builder paketobuildpacks/builder-jammy-full`
 
 ## Running
 
@@ -15,3 +15,6 @@ built-in PHP server.
 
 `curl http://localhost:8080`
 
+## Stack Support
+
+The Paketo PHP buildpack requires the Full Jammy Stack. See [stack docs](https://paketo.io/docs/concepts/stacks) for more details

--- a/php/httpd/README.md
+++ b/php/httpd/README.md
@@ -13,7 +13,7 @@ With the Pack CLI, this would involve setting `--env BP_PHP_SERVER=httpd`.
 
 ## Building
 
-`pack build php-httpd-sample --buildpack paketo-buildpacks/php`
+`pack build php-httpd-sample --buildpack paketo-buildpacks/php --builder paketobuildpacks/builder-jammy-full`
 
 ## Running
 
@@ -22,3 +22,7 @@ With the Pack CLI, this would involve setting `--env BP_PHP_SERVER=httpd`.
 ## Viewing
 
 `curl http://localhost:8080`
+
+## Stack Support
+
+The Paketo PHP buildpack requires the Full Jammy Stack. See [stack docs](https://paketo.io/docs/concepts/stacks) for more details

--- a/php/memcached_session_handler/README.md
+++ b/php/memcached_session_handler/README.md
@@ -28,7 +28,8 @@ pack build php-memcached-handler-sample \
 --env BP_PHP_WEB_DIR=htdocs \
 --env SERVICE_BINDING_ROOT=/bindings \
 --volume $PWD/binding:/bindings/php-memcached-session \
---buildpack paketo-buildpacks/php
+--buildpack paketo-buildpacks/php \
+--builder paketobuildpacks/builder-jammy-full
 ```
 
 ## Running
@@ -49,3 +50,7 @@ Observe the counter that displays the number of hits the page has had serving `2
 
 Alternatively, view `localhost:8080` in your browser a few times and see the
 page count increment.
+
+## Stack Support
+
+The Paketo PHP buildpack requires the Full Jammy Stack. See [stack docs](https://paketo.io/docs/concepts/stacks) for more details

--- a/php/nginx/README.md
+++ b/php/nginx/README.md
@@ -13,7 +13,7 @@ With the Pack CLI, this would involve setting `--env BP_PHP_SERVER=nginx`.
 
 ## Building
 
-`pack build php-nginx-sample --buildpack paketo-buildpacks/php`
+`pack build php-nginx-sample --buildpack paketo-buildpacks/php --builder paketobuildpacks/builder-jammy-full`
 
 ## Running
 
@@ -22,3 +22,7 @@ With the Pack CLI, this would involve setting `--env BP_PHP_SERVER=nginx`.
 ## Viewing
 
 `curl http://localhost:8080`
+
+## Stack Support
+
+The Paketo PHP buildpack requires the Full Jammy Stack. See [stack docs](https://paketo.io/docs/concepts/stacks) for more details

--- a/php/redis_session_handler/README.md
+++ b/php/redis_session_handler/README.md
@@ -25,7 +25,8 @@ pack build php-redis-handler-sample \
 --env BP_PHP_WEB_DIR=htdocs \
 --env SERVICE_BINDING_ROOT=/bindings \
 --volume $PWD/binding:/bindings/php-redis-session \
---buildpack paketo-buildpacks/php
+--buildpack paketo-buildpacks/php \
+--builder paketobuildpacks/builder-jammy-full
 ```
 
 ## Running
@@ -46,3 +47,7 @@ Observe the counter that displays the number of hits the page has had serving `2
 
 Alternatively, view `localhost:8080` in your browser a few times adn see the
 page count increment.
+
+## Stack Support
+
+The Paketo PHP buildpack requires the Full Jammy Stack. See [stack docs](https://paketo.io/docs/concepts/stacks) for more details


### PR DESCRIPTION
PHP is the rare case that doesn't run on any stack other than Full. It's easy for new users to overlook this!


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
