### PR TITLE
Bump gradle wrapper networkTimeout to 10000 in sample

### DIFF
--- a/.github/workflows/java-gradle.yml
+++ b/.github/workflows/java-gradle.yml
@@ -29,5 +29,5 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('java/gradle/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       # simulate the bindings
-      - run: cp bindings/gradle-wrapper/gradle-wrapper.properties gradle/wrapper/gradle-wrapper.properties && ./gradlew build
+      - run: ./gradlew build
         working-directory: java/gradle

--- a/java/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
-networkTimeout=1
+networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR changes `networkTimeout=1` to `networkTimeout=10000` in the gradle sample [gradle-wrapper.properties](https://github.com/paketo-buildpacks/samples/blob/main/java/gradle/gradle/wrapper/gradle-wrapper.properties) file and then changes the Action to use that properties file instead of copying a different file.

This fixes #642.

## Use Cases
<!-- An explanation of the use cases your change enables -->

We're building our buildpacks in a CI/CD Jenkins pipeline and pushing them to our internal AWS ECR. We're using the samples to test our builds and this sample recently started to fail. I would expect the sample to run out-of-the-box. I'm not a Java developer, so I had limited knowledge of where to start troubleshooting.

I was troubleshooting with @anthonydahanne in a [Slack thread](https://paketobuildpacks.slack.com/archives/C0124SD3GTG/p1698258102926649) and he advised me to make these changes and open this PR.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
