### PR TITLE
Use Werkzeug 2.2.2 version inorder to work with Flask for samples code

### DIFF
--- a/python/conda/environment.yml
+++ b/python/conda/environment.yml
@@ -1,3 +1,4 @@
 dependencies:
 - python=3.9
 - flask=2.0.2
+- Werkzeug==2.2.2


### PR DESCRIPTION
## Summary
This PR fixes this [issue](https://github.com/paketo-buildpacks/samples/issues/735) in the samples code
The issue seems to be import error. Flask cannot find the `Werkzeug` library
To fix it we need to add `Werkzeug` library 
More info: https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr

## Use Cases
We will be able to execute the sample example code