### PR TITLE
Bump target framework to `net8.0`

### DIFF
--- a/dotnet-core/aspnet/README.md
+++ b/dotnet-core/aspnet/README.md
@@ -6,7 +6,7 @@
 
 ## Running
 
-`docker run --interactive --tty --env PORT=8080 --publish 8080:8080 dotnet-aspnet-sample`
+`docker run --rm --env PORT=8080 --publish 8080:8080 dotnet-aspnet-sample`
 
 ## Viewing
 

--- a/dotnet-core/aspnet/aspnet.csproj
+++ b/dotnet-core/aspnet/aspnet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/dotnet-core/fdd-app/aspnet.deps.json
+++ b/dotnet-core/fdd-app/aspnet.deps.json
@@ -1,12 +1,12 @@
 {
   "runtimeTarget": {
-    "name": ".NETCoreApp,Version=v6.0/ubuntu.18.04-x64",
+    "name": ".NETCoreApp,Version=v8.0/ubuntu.22.04-x64",
     "signature": ""
   },
   "compilationOptions": {},
   "targets": {
-    ".NETCoreApp,Version=v6.0": {},
-    ".NETCoreApp,Version=v6.0/ubuntu.18.04-x64": {
+    ".NETCoreApp,Version=v8.0": {},
+    ".NETCoreApp,Version=v8.0/ubuntu.22.04-x64": {
       "aspnet/1.0.0": {
         "runtime": {
           "aspnet.dll": {}

--- a/dotnet-core/fdd-app/aspnet.runtimeconfig.json
+++ b/dotnet-core/fdd-app/aspnet.runtimeconfig.json
@@ -1,14 +1,14 @@
 {
   "runtimeOptions": {
-    "tfm": "net6.0",
+    "tfm": "net8.0",
     "frameworks": [
       {
         "name": "Microsoft.NETCore.App",
-        "version": "6.0.0"
+        "version": "8.0.10"
       },
       {
         "name": "Microsoft.AspNetCore.App",
-        "version": "6.0.0"
+        "version": "8.0.10"
       }
     ],
     "configProperties": {

--- a/dotnet-core/fde-app/aspnet.deps.json
+++ b/dotnet-core/fde-app/aspnet.deps.json
@@ -1,12 +1,12 @@
 {
   "runtimeTarget": {
-    "name": ".NETCoreApp,Version=v6.0/ubuntu.18.04-x64",
+    "name": ".NETCoreApp,Version=v8.0/ubuntu.22.04-x64",
     "signature": ""
   },
   "compilationOptions": {},
   "targets": {
-    ".NETCoreApp,Version=v6.0": {},
-    ".NETCoreApp,Version=v6.0/ubuntu.18.04-x64": {
+    ".NETCoreApp,Version=v8.0": {},
+    ".NETCoreApp,Version=v8.0/ubuntu.22.04-x64": {
       "aspnet/1.0.0": {
         "runtime": {
           "aspnet.dll": {}

--- a/dotnet-core/fde-app/aspnet.runtimeconfig.json
+++ b/dotnet-core/fde-app/aspnet.runtimeconfig.json
@@ -1,14 +1,14 @@
 {
   "runtimeOptions": {
-    "tfm": "net6.0",
+    "tfm": "net8.0",
     "frameworks": [
       {
         "name": "Microsoft.NETCore.App",
-        "version": "6.0.0"
+        "version": "8.0.10"
       },
       {
         "name": "Microsoft.AspNetCore.App",
-        "version": "6.0.0"
+        "version": "8.0.10"
       }
     ],
     "configProperties": {

--- a/dotnet-core/runtime/runtime.csproj
+++ b/dotnet-core/runtime/runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The dotnet-core/aspnet fails with recent Paketo Buildpacks Jammy Builder, due to
the fact that the version 6 runtime is no longer supported.
