### PR TITLE
Update `quarkus-native-image-maven` to use more up to date practices and updated to Java 21

### DIFF
--- a/java/native-image/quarkus-native-image-maven/README.md
+++ b/java/native-image/quarkus-native-image-maven/README.md
@@ -8,11 +8,11 @@
 pack build applications/quarkus-native \
   --builder paketobuildpacks/builder-jammy-tiny \
   --env BP_NATIVE_IMAGE=true \
-  --env BP_MAVEN_BUILD_ARGUMENTS="-Dquarkus.package.type=native-sources -Dmaven.test.skip=true package" \
+  --env BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS="-Dquarkus.package.type=native-sources" \
   --env BP_MAVEN_BUILT_ARTIFACT="target/native-sources" \
   --env BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE="native-sources/native-image.args" \
-  --env BP_NATIVE_IMAGE_BUILT_ARTIFACT="native-sources/getting-started-*-runner.jar" \
-  --env BP_JVM_VERSION=17
+  --env BP_NATIVE_IMAGE_BUILT_ARTIFACT="native-sources/*-runner.jar" \
+  --env BP_JVM_VERSION=21
 ```
 
 ## Running

--- a/java/native-image/quarkus-native-image-maven/pom.xml
+++ b/java/native-image/quarkus-native-image-maven/pom.xml
@@ -13,8 +13,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 


### PR DESCRIPTION
## Summary
The following was changed with the PR:

- Updated `maven.compiler` to 21
- Updated README.md to use `BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS` instead of `BP_MAVEN_BUILD_ARGUMENTS`. This change allows the default values in the build arguments to be used which includes the following:
  - `-Dmaven.test.skip=true --no-transfer-progress package`
- Updated README.md to use Java 21
- Updated README.md the `BP_NATIVE_IMAGE_BUILT_ARTIFACT` to use a wild card for the `runner.jar`

## Use Cases
Changing from `BP_MAVEN_BUILD_ARGUMENTS` to `BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS` allows the defaults given by `BP_MAVEN_BUILD_ARGUMENTS` to be utilized for free. If these change in the future, they will be automatically added without having to be aware of these changes.

## Checklist
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
