### PR TITLE
fix: replacing binary for amd64 with a go app

### DIFF
--- a/procfile/procfile-sample/Procfile
+++ b/procfile/procfile-sample/Procfile
@@ -1,1 +1,1 @@
-web: ./static-file-server-1.8.0-linux-amd64 --config config.yml
+web: go run main.go --config config.yml

--- a/procfile/procfile-sample/main.go
+++ b/procfile/procfile-sample/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+
+		file := filepath.Join("web", filepath.Clean(r.URL.Path[1:]))
+
+		info, err := os.Stat(file)
+		if os.IsNotExist(err) || info.IsDir() {
+			http.NotFound(w, r)
+			return
+		}
+
+		http.ServeFile(w, r, file)
+	})
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+}

--- a/procfile/procfile-sample/plan.toml
+++ b/procfile/procfile-sample/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "go"
+
+  [requires.metadata]
+    launch = true

--- a/procfile/procfile_test.go
+++ b/procfile/procfile_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 var builders tests.BuilderFlags
-var suite spec.Suite
 
 func init() {
 	flag.Var(&builders, "name", "the name a builder to test with")
@@ -82,8 +81,13 @@ func testProcfileWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 
 					var logs fmt.Stringer
 					image, logs, err = pack.Build.
-						WithPullPolicy("never").
+						WithPullPolicy("always").
 						WithBuilder(builder).
+						WithBuildpacks(
+							"index.docker.io/paketobuildpacks/go-dist",
+							"index.docker.io/paketobuildpacks/procfile",
+							"index.docker.io/paketocommunity/build-plan",
+						).
 						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR removes the binary for amd64 for serving static files on procfile example and replaces it with a go program.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This will allow the app to be built for multiple architectures.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
