### PR TITLE
Migrate Java samples to Ubuntu Resolute builder

### DIFF
--- a/.github/workflows/java-leiningen.yml
+++ b/.github/workflows/java-leiningen.yml
@@ -13,15 +13,12 @@ name: leiningen
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [11]
 
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 21
           distribution: 'zulu'
       - uses: actions/cache@v6
         with:

--- a/.github/workflows/java-leiningen.yml
+++ b/.github/workflows/java-leiningen.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test-all-samples.yml
+++ b/.github/workflows/test-all-samples.yml
@@ -55,18 +55,19 @@ jobs:
     - name: Test ${{ matrix.suite }}
       run: |
         # Suites the Paketo Ubuntu Resolute builder can build are migrated to it.
-        # Its bundled buildpacks cover Java/JVM, Node.js and Procfile out of the box.
-        # Go and Python are not embedded in the builder, but their buildpacks publish
-        # resolute-stack binaries, so the go/python smoke tests supply them explicitly
-        # (see WithBuildpacks in those tests); ca-certificates rides on the Go buildpack.
+        # Its bundled buildpacks cover Java/JVM, Node.js and Procfile out of the box,
+        # and the Python buildpack publishes resolute-stack binaries so the python
+        # smoke test supplies it explicitly (see WithBuildpacks in that test).
+        # The go suite (and ca-certificates, which builds a Go app) stays on jammy-full:
+        # the Go buildpack has an unresolved issue on resolute and is out of scope here.
         # dotnet-core, web-servers (httpd/nginx), ruby and php have no resolute-stack
-        # dependency binaries published upstream yet, so they stay on jammy-full.
+        # dependency binaries published upstream yet, so they also stay on jammy-full.
         # (Note: java/deps and java/tools-build use the Clojure Tools buildpack, whose
         # Clojure CLI dependency is published amd64-only; that is fine here because the
         # GitHub-hosted runners are amd64, but those two samples cannot be built on
         # arm64 with any builder until an arm64 Clojure CLI is published upstream.)
         case "${{ matrix.suite }}" in
-          ./java/*|nodejs|procfile|go|python|ca-certificates)
+          ./java/*|nodejs|procfile|python)
             BUILDER="paketobuildpacks/ubuntu-resolute-builder:latest" ;;
           *)
             BUILDER="paketobuildpacks/builder-jammy-full:latest" ;;

--- a/.github/workflows/test-all-samples.yml
+++ b/.github/workflows/test-all-samples.yml
@@ -55,11 +55,11 @@ jobs:
     - name: Test ${{ matrix.suite }}
       run: |
         # Suites the Paketo Ubuntu Resolute builder can build are migrated to it.
-        # Its bundled buildpacks cover Java/JVM, Node.js and Procfile out of the box,
-        # and the Python buildpack publishes resolute-stack binaries so the python
-        # smoke test supplies it explicitly (see WithBuildpacks in that test).
+        # Its bundled buildpacks cover Java/JVM, Node.js and Procfile out of the box.
         # The go suite (and ca-certificates, which builds a Go app) stays on jammy-full:
         # the Go buildpack has an unresolved issue on resolute and is out of scope here.
+        # The python suite also stays on jammy-full: its samples (including uv/pixi) are
+        # owned by the Python maintainers and don't opt into a resolute run/buildpack.
         # dotnet-core, web-servers (httpd/nginx), ruby and php have no resolute-stack
         # dependency binaries published upstream yet, so they also stay on jammy-full.
         # (Note: java/deps and java/tools-build use the Clojure Tools buildpack, whose
@@ -67,7 +67,7 @@ jobs:
         # GitHub-hosted runners are amd64, but those two samples cannot be built on
         # arm64 with any builder until an arm64 Clojure CLI is published upstream.)
         case "${{ matrix.suite }}" in
-          ./java/*|nodejs|procfile|python)
+          ./java/*|nodejs|procfile)
             BUILDER="paketobuildpacks/ubuntu-resolute-builder:latest" ;;
           *)
             BUILDER="paketobuildpacks/builder-jammy-full:latest" ;;

--- a/.github/workflows/test-all-samples.yml
+++ b/.github/workflows/test-all-samples.yml
@@ -54,7 +54,24 @@ jobs:
 
     - name: Test ${{ matrix.suite }}
       run: |
-        ./scripts/smoke.sh --builder paketobuildpacks/builder-jammy-full:latest --suite ${{ matrix.suite }}
+        # Suites the Paketo Ubuntu Resolute builder can build are migrated to it.
+        # Its bundled buildpacks cover Java/JVM, Node.js and Procfile out of the box.
+        # Go and Python are not embedded in the builder, but their buildpacks publish
+        # resolute-stack binaries, so the go/python smoke tests supply them explicitly
+        # (see WithBuildpacks in those tests); ca-certificates rides on the Go buildpack.
+        # dotnet-core, web-servers (httpd/nginx), ruby and php have no resolute-stack
+        # dependency binaries published upstream yet, so they stay on jammy-full.
+        # (Note: java/deps and java/tools-build use the Clojure Tools buildpack, whose
+        # Clojure CLI dependency is published amd64-only; that is fine here because the
+        # GitHub-hosted runners are amd64, but those two samples cannot be built on
+        # arm64 with any builder until an arm64 Clojure CLI is published upstream.)
+        case "${{ matrix.suite }}" in
+          ./java/*|nodejs|procfile|go|python|ca-certificates)
+            BUILDER="paketobuildpacks/ubuntu-resolute-builder:latest" ;;
+          *)
+            BUILDER="paketobuildpacks/builder-jammy-full:latest" ;;
+        esac
+        ./scripts/smoke.sh --builder "$BUILDER" --suite ${{ matrix.suite }}
 
     - name: File Issue
       if: ${{ failure() && github.event_name != 'pull_request' }}

--- a/.github/workflows/test-pull-request-java.yml
+++ b/.github/workflows/test-pull-request-java.yml
@@ -86,24 +86,12 @@ jobs:
           export TESTCONTAINERS_RYUK_DISABLED=true
           export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
 
-          # Map the right builder image for the Java sample folder
-          case "${{ matrix.java_sample_folder }}" in
-            "java/akka/"*)
-              BUILDER_IMAGE="paketobuildpacks/builder-jammy-base:latest"
-              ;;
-            "java/dist-zip/"*)
-              BUILDER_IMAGE="paketobuildpacks/builder-jammy-base:latest"
-              ;;
-            "java/java-node/gradle-node/"*)
-              BUILDER_IMAGE="paketobuildpacks/builder-jammy-base:latest"
-              ;;
-            "java/java-node/maven-yarn/"*)
-              BUILDER_IMAGE="paketobuildpacks/builder-jammy-base:latest"
-              ;;
-            *)
-              BUILDER_IMAGE="paketobuildpacks/builder-jammy-tiny:latest"
-              ;;
-          esac
+          # All Java samples now build with the Paketo Ubuntu Resolute builder.
+          # It bundles the Java, Java Native Image, Node.js and Procfile buildpacks,
+          # and its default (base) run image includes a full Linux distribution
+          # (bash, etc.), so samples that previously required the jammy-base builder
+          # work here too.
+          BUILDER_IMAGE="paketobuildpacks/ubuntu-resolute-builder:latest"
 
           ./scripts/smoke.sh --suite "${{ matrix.java_sample_folder }}" \
                              --builder "$BUILDER_IMAGE"

--- a/go/go_test.go
+++ b/go/go_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -52,12 +51,6 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 		it.Before(func() {
 			pack = occam.NewPack().WithVerbose().WithNoColor()
 			docker = occam.NewDocker()
-
-			// The Ubuntu Resolute builder does not embed the Go buildpack, so it
-			// must be supplied explicitly at build time (see WithBuildpacks below).
-			if strings.Contains(builder, "resolute") {
-				Expect(docker.Pull.Execute("index.docker.io/paketobuildpacks/go")).To(Succeed())
-			}
 		})
 
 		context("detects a Go app", func() {
@@ -89,13 +82,10 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					build := pack.Build.
+					image, logs, err = pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder)
-					if strings.Contains(builder, "resolute") {
-						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/go")
-					}
-					image, logs, err = build.Execute(name, source)
+						WithBuilder(builder).
+						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Distribution")))
@@ -120,13 +110,10 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					build := pack.Build.
+					image, logs, err = pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder)
-					if strings.Contains(builder, "resolute") {
-						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/go")
-					}
-					image, logs, err = build.Execute(name, source)
+						WithBuilder(builder).
+						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Distribution")))

--- a/go/go_test.go
+++ b/go/go_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +52,12 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 		it.Before(func() {
 			pack = occam.NewPack().WithVerbose().WithNoColor()
 			docker = occam.NewDocker()
+
+			// The Ubuntu Resolute builder does not embed the Go buildpack, so it
+			// must be supplied explicitly at build time (see WithBuildpacks below).
+			if strings.Contains(builder, "resolute") {
+				Expect(docker.Pull.Execute("index.docker.io/paketobuildpacks/go")).To(Succeed())
+			}
 		})
 
 		context("detects a Go app", func() {
@@ -82,10 +89,13 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder).
-						Execute(name, source)
+						WithBuilder(builder)
+					if strings.Contains(builder, "resolute") {
+						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/go")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Distribution")))
@@ -110,10 +120,13 @@ func testGoWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder).
-						Execute(name, source)
+						WithBuilder(builder)
+					if strings.Contains(builder, "resolute") {
+						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/go")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Go Distribution")))

--- a/java/akka/README.md
+++ b/java/akka/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/akka
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/akka --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=11
 ```
 

--- a/java/akka/README.md
+++ b/java/akka/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/akka --env BP_JVM_VERSION=11
+pack build applications/akka --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=11
 ```
 
 ## Running

--- a/java/application-insights/README.md
+++ b/java/application-insights/README.md
@@ -21,7 +21,7 @@ echo "<Instrumentation Key>" > binding/InstrumentationKey
 ## Building
 
 ```bash
-pack build applications/application-insights --env BP_JVM_VERSION=17 --volume "$(pwd)/binding:/platform/bindings/application-insights"
+pack build applications/application-insights --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17 --volume "$(pwd)/binding:/platform/bindings/application-insights"
 ```
 
 ## Running

--- a/java/application-insights/README.md
+++ b/java/application-insights/README.md
@@ -21,6 +21,14 @@ echo "<Instrumentation Key>" > binding/InstrumentationKey
 ## Building
 
 ```bash
+pack build applications/application-insights --volume "$(pwd)/binding:/platform/bindings/application-insights"
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/application-insights --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17 --volume "$(pwd)/binding:/platform/bindings/application-insights"
 ```
 

--- a/java/aspectj/README.md
+++ b/java/aspectj/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/aspectj --env BP_JVM_VERSION=17
+pack build applications/aspectj --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17
 ```
 
 ## Running

--- a/java/aspectj/README.md
+++ b/java/aspectj/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/aspectj
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/aspectj --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17
 ```
 

--- a/java/deps/README.md
+++ b/java/deps/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/clojure-deps
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/clojure-deps --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=11
 ```
 

--- a/java/deps/README.md
+++ b/java/deps/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/clojure-deps --env BP_JVM_VERSION=11
+pack build applications/clojure-deps --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=11
 ```
 
 ## Running

--- a/java/deps/deps.edn
+++ b/java/deps/deps.edn
@@ -1,9 +1,9 @@
 {:deps
-          {io.pedestal/pedestal.service {:mvn/version "0.5.10"}
-           io.pedestal/pedestal.route   {:mvn/version "0.5.10"}
-           io.pedestal/pedestal.jetty   {:mvn/version "0.5.10"}
-           org.clojure/data.json        {:mvn/version "2.4.0"}
-           org.slf4j/slf4j-simple       {:mvn/version "1.7.36"}}
+          {io.pedestal/pedestal.service {:mvn/version "0.7.2"}
+           io.pedestal/pedestal.route   {:mvn/version "0.7.2"}
+           io.pedestal/pedestal.jetty   {:mvn/version "0.7.2"}
+           org.clojure/data.json        {:mvn/version "2.5.2"}
+           org.slf4j/slf4j-simple       {:mvn/version "2.0.18"}}
  :paths ["src"]
  :aliases {:uberjar {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
                      :exec-fn hf.depstar/uberjar

--- a/java/dist-zip/README.md
+++ b/java/dist-zip/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/dist-zip --env BP_GRADLE_BUILD_ARGUMENTS="--no-daemon -x test bootDistZip" --env BP_GRADLE_BUILT_ARTIFACT="build/distributions/*.zip" --env BP_JVM_VERSION=17
+pack build applications/dist-zip --builder paketobuildpacks/ubuntu-resolute-builder --env BP_GRADLE_BUILD_ARGUMENTS="--no-daemon -x test bootDistZip" --env BP_GRADLE_BUILT_ARTIFACT="build/distributions/*.zip" --env BP_JVM_VERSION=17
 ```
 
 ## Running

--- a/java/dist-zip/README.md
+++ b/java/dist-zip/README.md
@@ -5,6 +5,16 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/dist-zip --env BP_GRADLE_BUILD_ARGUMENTS="--no-daemon -x test bootDistZip" --env BP_GRADLE_BUILT_ARTIFACT="build/distributions/*.zip" --env BP_JVM_VERSION=17
+```
+
+> This sample's Gradle build pins a Java 17 toolchain, so `BP_JVM_VERSION=17` is required.
+
+### Advanced
+
+You can also select a specific builder by passing the `--builder` flag:
+
+```bash
 pack build applications/dist-zip --builder paketobuildpacks/ubuntu-resolute-builder --env BP_GRADLE_BUILD_ARGUMENTS="--no-daemon -x test bootDistZip" --env BP_GRADLE_BUILT_ARTIFACT="build/distributions/*.zip" --env BP_JVM_VERSION=17
 ```
 

--- a/java/dist-zip/build.gradle
+++ b/java/dist-zip/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.+'
+	id 'org.springframework.boot' version '4.1.+'
 	id 'io.spring.dependency-management' version '1.1.+'
 	id 'application'
 }

--- a/java/gradle/README.md
+++ b/java/gradle/README.md
@@ -5,13 +5,13 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder
+pack build applications/gradle
 ```
 
 Alternatively, if you want to attach a `gradle.properties` and/or a `gradle-wrapper.properties` file to pass additional configuration to Gradle (Wrapper).
 
 ```bash
-pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder --volume $(pwd)/bindings:/platform/bindings
+pack build applications/gradle --volume $(pwd)/bindings:/platform/bindings
 ```
 
 The command above will use: 
@@ -20,14 +20,23 @@ The command above will use:
 
 ```bash
 cp ~/.gradle/gradle.properties java/gradle/bindings/gradle/gradle.properties
-pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder --volume $(pwd)/bindings:/platform/bindings
+pack build applications/gradle --volume $(pwd)/bindings:/platform/bindings
 ```
 
 * the sample `gradle-wrapper.properties` file from this repo. It may be more useful to copy your local `gradle-wrapper.properties` file first.
 
 ```bash
 cp ~/gradle/wrapper/gradle-wrapper.properties java/gradle/bindings/gradle-wrapper/gradle-wrapper.properties
-pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder --volume $(pwd)/bindings:/platform/bindings
+pack build applications/gradle --volume $(pwd)/bindings:/platform/bindings
+```
+
+### Advanced
+
+You can also select a specific builder by passing the `--builder` flag:
+
+```bash
+pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder
+```
 
 ## Running
 

--- a/java/gradle/README.md
+++ b/java/gradle/README.md
@@ -5,13 +5,13 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/gradle
+pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder
 ```
 
 Alternatively, if you want to attach a `gradle.properties` and/or a `gradle-wrapper.properties` file to pass additional configuration to Gradle (Wrapper).
 
 ```bash
-pack build applications/gradle --volume $(pwd)/bindings:/platform/bindings
+pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder --volume $(pwd)/bindings:/platform/bindings
 ```
 
 The command above will use: 
@@ -20,14 +20,14 @@ The command above will use:
 
 ```bash
 cp ~/.gradle/gradle.properties java/gradle/bindings/gradle/gradle.properties
-pack build applications/gradle --volume $(pwd)/bindings:/platform/bindings
+pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder --volume $(pwd)/bindings:/platform/bindings
 ```
 
 * the sample `gradle-wrapper.properties` file from this repo. It may be more useful to copy your local `gradle-wrapper.properties` file first.
 
 ```bash
 cp ~/gradle/wrapper/gradle-wrapper.properties java/gradle/bindings/gradle-wrapper/gradle-wrapper.properties
-pack build applications/gradle --volume $(pwd)/bindings:/platform/bindings
+pack build applications/gradle --builder paketobuildpacks/ubuntu-resolute-builder --volume $(pwd)/bindings:/platform/bindings
 
 ## Running
 

--- a/java/gradle/build.gradle
+++ b/java/gradle/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.+'
+	id 'org.springframework.boot' version '4.1.+'
 	id 'io.spring.dependency-management' version '1.1.+'
 }
 

--- a/java/jar/README.md
+++ b/java/jar/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/jar  --env BP_JVM_VERSION=17
+pack build applications/jar --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17
 ```
 
 ## Running

--- a/java/jar/README.md
+++ b/java/jar/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/jar
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/jar --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17
 ```
 

--- a/java/java-node/gradle-node/README.md
+++ b/java/java-node/gradle-node/README.md
@@ -5,7 +5,15 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/gradle-node --env BP_JVM_VERSION=21 --env BP_JAVA_INSTALL_NODE=true --env BP_NODE_PROJECT_PATH=frontend --builder paketobuildpacks/ubuntu-resolute-builder
+pack build applications/gradle-node --env BP_JAVA_INSTALL_NODE=true --env BP_NODE_PROJECT_PATH=frontend
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
+pack build applications/gradle-node --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=21 --env BP_JAVA_INSTALL_NODE=true --env BP_NODE_PROJECT_PATH=frontend
 ```
 
 ## Running

--- a/java/java-node/gradle-node/README.md
+++ b/java/java-node/gradle-node/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/gradle-node --env BP_JVM_VERSION=21 --env BP_JAVA_INSTALL_NODE=true --env BP_NODE_PROJECT_PATH=frontend --builder paketobuildpacks/builder-jammy-base
+pack build applications/gradle-node --env BP_JVM_VERSION=21 --env BP_JAVA_INSTALL_NODE=true --env BP_NODE_PROJECT_PATH=frontend --builder paketobuildpacks/ubuntu-resolute-builder
 ```
 
 ## Running

--- a/java/java-node/gradle-node/build.gradle
+++ b/java/java-node/gradle-node/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.+'
+	id 'org.springframework.boot' version '4.1.+'
 	id 'io.spring.dependency-management' version '1.1.+'
 }
 

--- a/java/java-node/maven-yarn/README.md
+++ b/java/java-node/maven-yarn/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/maven-yarn --env BP_JAVA_INSTALL_NODE=true
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/maven-yarn --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17 --env BP_JAVA_INSTALL_NODE=true
 ```
 

--- a/java/java-node/maven-yarn/README.md
+++ b/java/java-node/maven-yarn/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/maven-yarn --env BP_JVM_VERSION=17 --env BP_JAVA_INSTALL_NODE=true
+pack build applications/maven-yarn --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17 --env BP_JAVA_INSTALL_NODE=true
 ```
 
 ## Running

--- a/java/kotlin/README.md
+++ b/java/kotlin/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/kotlin
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/kotlin --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17
 ```
 

--- a/java/kotlin/README.md
+++ b/java/kotlin/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/kotlin  --env BP_JVM_VERSION=17
+pack build applications/kotlin --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17
 ```
 
 ## Running

--- a/java/kotlin/build.gradle.kts
+++ b/java/kotlin/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-	id("org.springframework.boot") version "3.+"
-	id("io.spring.dependency-management") version "1.+"
-	kotlin("jvm") version "1.9.+"
-	kotlin("plugin.spring") version "1.9.+"
+	id("org.springframework.boot") version "4.1.+"
+	id("io.spring.dependency-management") version "1.1.+"
+	kotlin("jvm") version "2.2.+"
+	kotlin("plugin.spring") version "2.2.+"
 }
 
 group = "io.paketo"

--- a/java/leiningen/README.md
+++ b/java/leiningen/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/leiningen  --env BP_JVM_VERSION=11
+pack build applications/leiningen --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=11
 ```
 
 ## Running

--- a/java/leiningen/README.md
+++ b/java/leiningen/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/leiningen
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/leiningen --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=11
 ```
 

--- a/java/leiningen/project.clj
+++ b/java/leiningen/project.clj
@@ -1,11 +1,11 @@
 (defproject demo "0.0.1-SNAPSHOT"
-  :dependencies [[org.clojure/clojure "1.11.1"]
-                 [io.pedestal/pedestal.service "0.5.10"]
-                 [io.pedestal/pedestal.jetty "0.5.10"]
-                 [ch.qos.logback/logback-classic "1.2.11" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.36"]
-                 [org.slf4j/jcl-over-slf4j "1.7.36"]
-                 [org.slf4j/log4j-over-slf4j "1.7.36"]]
+  :dependencies [[org.clojure/clojure "1.12.5"]
+                 [io.pedestal/pedestal.service "0.7.2"]
+                 [io.pedestal/pedestal.jetty "0.7.2"]
+                 [ch.qos.logback/logback-classic "1.5.38" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "2.0.18"]
+                 [org.slf4j/jcl-over-slf4j "2.0.18"]
+                 [org.slf4j/log4j-over-slf4j "2.0.18"]]
   :resource-paths ["config"]
   :main ^:skip-aot lein-source.server
   :profiles {:uberjar {:aot :all

--- a/java/maven/README.md
+++ b/java/maven/README.md
@@ -5,20 +5,28 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/maven --builder paketobuildpacks/ubuntu-resolute-builder
+pack build applications/maven
 ```
 
 Alternatively, if you want to attach a Maven `settings.xml` file to pass additional configuration to Maven.
 
 ```bash
-pack build applications/maven --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17 --volume $(pwd)/bindings:/platform/bindings
+pack build applications/maven --volume $(pwd)/bindings:/platform/bindings
 ```
 
 The command above will use the sample `settings.xml` file from this repo. It may be more useful to copy your local `settings.xml` first.
 
 ```bash
 cp ~/.m2/settings.xml java/maven/bindings/maven/settings.xml
-pack build applications/maven --builder paketobuildpacks/ubuntu-resolute-builder --volume $(pwd)/bindings:/platform/bindings
+pack build applications/maven --volume $(pwd)/bindings:/platform/bindings
+```
+
+### Advanced
+
+You can also select a specific builder by passing the `--builder` flag:
+
+```bash
+pack build applications/maven --builder paketobuildpacks/ubuntu-resolute-builder
 ```
 
 ## Running

--- a/java/maven/README.md
+++ b/java/maven/README.md
@@ -5,20 +5,20 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/maven
+pack build applications/maven --builder paketobuildpacks/ubuntu-resolute-builder
 ```
 
 Alternatively, if you want to attach a Maven `settings.xml` file to pass additional configuration to Maven.
 
 ```bash
-pack build applications/maven --env BP_JVM_VERSION=17 --volume $(pwd)/bindings:/platform/bindings
+pack build applications/maven --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17 --volume $(pwd)/bindings:/platform/bindings
 ```
 
 The command above will use the sample `settings.xml` file from this repo. It may be more useful to copy your local `settings.xml` first.
 
 ```bash
 cp ~/.m2/settings.xml java/maven/bindings/maven/settings.xml
-pack build applications/maven --volume $(pwd)/bindings:/platform/bindings
+pack build applications/maven --builder paketobuildpacks/ubuntu-resolute-builder --volume $(pwd)/bindings:/platform/bindings
 ```
 
 ## Running

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -47,6 +47,19 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
+                    <imageBuilder>paketobuildpacks/ubuntu-resolute-builder:latest</imageBuilder>
+                    <image>
+						<name>all</name>
+                        <env>
+                            <BP_JVM_VERSION>25</BP_JVM_VERSION>
+<!--							Some Spring Boot performance features; see https://blog.paketo.io/posts/spring-boot-performance/ -->
+<!--                            <BP_JVM_AOTCACHE_ENABLED>true</BP_JVM_AOTCACHE_ENABLED>-->
+<!--                            <BP_SPRING_AOT_ENABLED>true</BP_SPRING_AOT_ENABLED>-->
+<!--                            <JAVA_TOOL_OPTIONS>-XX:+UseCompactObjectHeaders -Dspring.threads.virtual.enabled=true</JAVA_TOOL_OPTIONS>-->
+<!--                            <BPE_DELIM_JAVA_TOOL_OPTIONS xml:space="preserve"> </BPE_DELIM_JAVA_TOOL_OPTIONS>-->
+<!--                            <BPE_APPEND_JAVA_TOOL_OPTIONS>-XX:+UseCompactObjectHeaders -Dspring.threads.virtual.enabled=true</BPE_APPEND_JAVA_TOOL_OPTIONS>-->
+                        </env>
+                    </image>
 					<layers>
 						<enabled>true</enabled>
 					</layers>

--- a/java/native-image/public-static-main-native-image-maven/README.md
+++ b/java/native-image/public-static-main-native-image-maven/README.md
@@ -8,7 +8,8 @@ This is a basic Java app (i.e. public static void main) built using Native Image
 
 ```bash
 pack build applications/native-image \
-  --builder paketobuildpacks/builder-jammy-tiny \
+  --builder paketobuildpacks/ubuntu-resolute-builder \
+  --run-image paketobuildpacks/ubuntu-resolute-run-tiny \
   --env BP_NATIVE_IMAGE=true \
   --env BP_JVM_VERSION=25
 ```

--- a/java/native-image/public-static-main-native-image-maven/README.md
+++ b/java/native-image/public-static-main-native-image-maven/README.md
@@ -14,6 +14,8 @@ pack build applications/native-image \
   --env BP_JVM_VERSION=25
 ```
 
+> **Note:** `--run-image paketobuildpacks/ubuntu-resolute-run-tiny` is required here because the Ubuntu Resolute builder's default run image is the full `run` variant, not `run-tiny`. The tiny run image is the recommended base for GraalVM native-image binaries, so this sample explicitly opts into it.
+
 ## Running
 
 ```bash

--- a/java/native-image/public-static-main-native-image-maven/smoke_test/java_native_image_public_static_main_test.go
+++ b/java/native-image/public-static-main-native-image-maven/smoke_test/java_native_image_public_static_main_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,6 +51,12 @@ func testPublicStaticMainWithBuilder(builder string) func(*testing.T, spec.G, sp
 		it.Before(func() {
 			pack = occam.NewPack().WithVerbose().WithNoColor()
 			docker = occam.NewDocker()
+
+			// The tiny run image is not the builder's default, so pre-pull it (the build
+			// below runs with --pull-policy never) when running on the Resolute builder.
+			if !strings.Contains(builder, "jammy") {
+				Expect(docker.Pull.Execute("paketobuildpacks/ubuntu-resolute-run-tiny:latest")).To(Succeed())
+			}
 		})
 
 		context("detects a Java Native Image app", func() {
@@ -81,12 +88,18 @@ func testPublicStaticMainWithBuilder(builder string) func(*testing.T, spec.G, sp
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
 						WithEnv(map[string]string{"BP_NATIVE_IMAGE": "true", "BP_JVM_VERSION": "25"}).
 						WithBuilder(builder).
-						WithGID("123").
-						Execute(name, source)
+						WithGID("123")
+					// The Ubuntu Resolute builder's default run image is the full `run`
+					// variant; native images should run on the tiny run image, so opt into
+					// it explicitly here (matching the sample's README and pom.xml).
+					if !strings.Contains(builder, "jammy") {
+						build = build.WithRunImage("paketobuildpacks/ubuntu-resolute-run-tiny:latest")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))

--- a/java/native-image/quarkus-native-image-maven/README.md
+++ b/java/native-image/quarkus-native-image-maven/README.md
@@ -16,6 +16,8 @@ pack build applications/quarkus-native \
   --env BP_JVM_VERSION=21
 ```
 
+> **Note:** `--run-image paketobuildpacks/ubuntu-resolute-run-tiny` is required here because the Ubuntu Resolute builder's default run image is the full `run` variant, not `run-tiny`. The tiny run image is the recommended base for GraalVM native-image binaries, so this sample explicitly opts into it.
+
 ## Running
 
 ```bash

--- a/java/native-image/quarkus-native-image-maven/README.md
+++ b/java/native-image/quarkus-native-image-maven/README.md
@@ -6,7 +6,8 @@
 
 ```bash
 pack build applications/quarkus-native \
-  --builder paketobuildpacks/builder-jammy-tiny \
+  --builder paketobuildpacks/ubuntu-resolute-builder \
+  --run-image paketobuildpacks/ubuntu-resolute-run-tiny \
   --env BP_NATIVE_IMAGE=true \
   --env BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS="-Dquarkus.package.type=native-sources" \
   --env BP_MAVEN_BUILT_ARTIFACT="target/native-sources" \

--- a/java/native-image/quarkus-native-image-maven/pom.xml
+++ b/java/native-image/quarkus-native-image-maven/pom.xml
@@ -9,7 +9,11 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.38.0</quarkus.platform.version>
+        <!-- Pinned to 3.36.0: Quarkus 3.37+ emits `-o <name> -jar <name>.jar` in
+             native-image.args, which trips a bug in the Paketo Native Image buildpack
+             (replaceJarArguments strips the -o value, breaking the native-image call).
+             Bump once that buildpack is fixed. -->
+        <quarkus.platform.version>3.36.0</quarkus.platform.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/java/native-image/quarkus-native-image-maven/pom.xml
+++ b/java/native-image/quarkus-native-image-maven/pom.xml
@@ -9,9 +9,9 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.38.2</quarkus.platform.version>
+        <quarkus.platform.version>3.38.0</quarkus.platform.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
-        <surefire-plugin.version>3.5.6</surefire-plugin.version>
+        <surefire-plugin.version>3.5.5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>

--- a/java/native-image/quarkus-native-image-maven/smoke_test/java_native_image_quarkus_native_test.go
+++ b/java/native-image/quarkus-native-image-maven/smoke_test/java_native_image_quarkus_native_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +52,12 @@ func testQuarkusWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 		it.Before(func() {
 			pack = occam.NewPack().WithVerbose().WithNoColor()
 			docker = occam.NewDocker()
+
+			// The tiny run image is not the builder's default, so pre-pull it (the build
+			// below runs with --pull-policy never) when running on the Resolute builder.
+			if !strings.Contains(builder, "jammy") {
+				Expect(docker.Pull.Execute("paketobuildpacks/ubuntu-resolute-run-tiny:latest")).To(Succeed())
+			}
 		})
 
 		context("detects a Java Native Image app", func() {
@@ -82,7 +89,7 @@ func testQuarkusWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
 						WithEnv(map[string]string{
 							"BP_JVM_VERSION":                       "25",
@@ -93,8 +100,14 @@ func testQuarkusWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 							"BP_NATIVE_IMAGE_BUILT_ARTIFACT":       "native-sources/getting-started-*-runner.jar",
 						}).
 						WithBuilder(builder).
-						WithGID("123").
-						Execute(name, source)
+						WithGID("123")
+					// The Ubuntu Resolute builder's default run image is the full `run`
+					// variant; native images should run on the tiny run image, so opt into
+					// it explicitly here (matching the sample's README and pom.xml).
+					if !strings.Contains(builder, "jammy") {
+						build = build.WithRunImage("paketobuildpacks/ubuntu-resolute-run-tiny:latest")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for BellSoft Liberica")))

--- a/java/native-image/spring-boot-native-image-gradle/README.md
+++ b/java/native-image/spring-boot-native-image-gradle/README.md
@@ -12,6 +12,8 @@ pack build applications/native-image \
   --env BP_JVM_VERSION=25
 ```
 
+> **Note:** `--run-image paketobuildpacks/ubuntu-resolute-run-tiny` is required here (and mirrored by `runImage` in `build.gradle`) because the Ubuntu Resolute builder's default run image is the full `run` variant, not `run-tiny`. The tiny run image is the recommended base for GraalVM native-image binaries, so this sample explicitly opts into it.
+
 ### With the Spring Boot Gradle Plugin
 
 ```bash

--- a/java/native-image/spring-boot-native-image-gradle/README.md
+++ b/java/native-image/spring-boot-native-image-gradle/README.md
@@ -6,7 +6,8 @@
 
 ```bash
 pack build applications/native-image \
-  --builder paketobuildpacks/builder-jammy-tiny \
+  --builder paketobuildpacks/ubuntu-resolute-builder \
+  --run-image paketobuildpacks/ubuntu-resolute-run-tiny \
   --env BP_NATIVE_IMAGE=true \
   --env BP_JVM_VERSION=25
 ```

--- a/java/native-image/spring-boot-native-image-gradle/build.gradle
+++ b/java/native-image/spring-boot-native-image-gradle/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.+'
-    id 'org.graalvm.buildtools.native' version '0.11.+'
+	id 'org.springframework.boot' version '4.1.+'
+    id 'org.graalvm.buildtools.native' version '1.1.+'
 	id 'io.spring.dependency-management' version '1.1.+'
 }
 
@@ -39,8 +39,6 @@ test {
 }
 
 tasks.named("bootBuildImage") {
-    builder = "paketobuildpacks/builder-jammy-buildpackless-tiny"
-    buildpacks = [
-        "paketobuildpacks/java-native-image"
-    ]
+    builder = "paketobuildpacks/ubuntu-resolute-builder:latest"
+    runImage = "paketobuildpacks/ubuntu-resolute-run-tiny:latest"
 }

--- a/java/native-image/spring-boot-native-image-gradle/smoke_test/java_native_image_gradle_test.go
+++ b/java/native-image/spring-boot-native-image-gradle/smoke_test/java_native_image_gradle_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,6 +51,12 @@ func testGradleWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 		it.Before(func() {
 			pack = occam.NewPack().WithVerbose().WithNoColor()
 			docker = occam.NewDocker()
+
+			// The tiny run image is not the builder's default, so pre-pull it (the build
+			// below runs with --pull-policy never) when running on the Resolute builder.
+			if !strings.Contains(builder, "jammy") {
+				Expect(docker.Pull.Execute("paketobuildpacks/ubuntu-resolute-run-tiny:latest")).To(Succeed())
+			}
 		})
 
 		context("detects a Java Native Image app", func() {
@@ -81,13 +88,19 @@ func testGradleWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
 						WithEnv(map[string]string{
 							"BP_NATIVE_IMAGE": "true", "BP_JVM_VERSION": "25"}).
 						WithBuilder(builder).
-						WithGID("123").
-						Execute(name, source)
+						WithGID("123")
+					// The Ubuntu Resolute builder's default run image is the full `run`
+					// variant; native images should run on the tiny run image, so opt into
+					// it explicitly here (matching the sample's README and build.gradle).
+					if !strings.Contains(builder, "jammy") {
+						build = build.WithRunImage("paketobuildpacks/ubuntu-resolute-run-tiny:latest")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					container, err = docker.Container.Run.

--- a/java/native-image/spring-boot-native-image-maven/README.md
+++ b/java/native-image/spring-boot-native-image-maven/README.md
@@ -14,6 +14,8 @@ pack build applications/native-image \
   --env BP_JVM_VERSION=25
 ```
 
+> **Note:** `--run-image paketobuildpacks/ubuntu-resolute-run-tiny` is required here (and mirrored by `runImage` in `pom.xml`) because the Ubuntu Resolute builder's default run image is the full `run` variant, not `run-tiny`. The tiny run image is the recommended base for GraalVM native-image binaries, so this sample explicitly opts into it.
+
 ### With the Spring Boot Maven Plugin
 
 ```bash

--- a/java/native-image/spring-boot-native-image-maven/README.md
+++ b/java/native-image/spring-boot-native-image-maven/README.md
@@ -8,7 +8,8 @@
 
 ```bash
 pack build applications/native-image \
-  --builder paketobuildpacks/builder-jammy-tiny \
+  --builder paketobuildpacks/ubuntu-resolute-builder \
+  --run-image paketobuildpacks/ubuntu-resolute-run-tiny \
   --env BP_MAVEN_ACTIVE_PROFILES=native \
   --env BP_JVM_VERSION=25
 ```

--- a/java/native-image/spring-boot-native-image-maven/pom.xml
+++ b/java/native-image/spring-boot-native-image-maven/pom.xml
@@ -50,10 +50,8 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
           <image>
-            <builder>paketobuildpacks/builder-jammy-buildpackless-tiny</builder>
-            <buildpacks>
-              <buildpack>paketobuildpacks/java-native-image</buildpack>
-            </buildpacks>
+            <builder>paketobuildpacks/ubuntu-resolute-builder:latest</builder>
+            <runImage>paketobuildpacks/ubuntu-resolute-run-tiny:latest</runImage>
           </image>
         </configuration>
 			</plugin>

--- a/java/native-image/spring-boot-native-image-maven/smoke_test/java_native_image_maven_test.go
+++ b/java/native-image/spring-boot-native-image-maven/smoke_test/java_native_image_maven_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,6 +51,12 @@ func testMavenWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 		it.Before(func() {
 			pack = occam.NewPack().WithVerbose().WithNoColor()
 			docker = occam.NewDocker()
+
+			// The tiny run image is not the builder's default, so pre-pull it (the build
+			// below runs with --pull-policy never) when running on the Resolute builder.
+			if !strings.Contains(builder, "jammy") {
+				Expect(docker.Pull.Execute("paketobuildpacks/ubuntu-resolute-run-tiny:latest")).To(Succeed())
+			}
 		})
 
 		context("detects a Java Native Image app", func() {
@@ -81,15 +88,21 @@ func testMavenWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
 						WithEnv(map[string]string{
 							"BP_NATIVE_IMAGE":          "true",
 							"BP_MAVEN_BUILD_ARGUMENTS": "-Dmaven.test.skip=true --no-transfer-progress -Pnative package",
 							"BP_JVM_VERSION":           "25"}).
 						WithBuilder(builder).
-						WithGID("123").
-						Execute(name, source)
+						WithGID("123")
+					// The Ubuntu Resolute builder's default run image is the full `run`
+					// variant; native images should run on the tiny run image, so opt into
+					// it explicitly here (matching the sample's README and pom.xml).
+					if !strings.Contains(builder, "jammy") {
+						build = build.WithRunImage("paketobuildpacks/ubuntu-resolute-run-tiny:latest")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					container, err = docker.Container.Run.

--- a/java/opentelemetry/README.md
+++ b/java/opentelemetry/README.md
@@ -6,8 +6,8 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 
 ```bash
 pack build applications/opentelemetry \
-    --buildpack paketo-buildpacks/java \
-    --buildpack docker.io/paketobuildpacks/opentelemetry \
+    --buildpack docker.io/paketobuildpacks/java:latest \
+    --buildpack docker.io/paketobuildpacks/opentelemetry:latest \
     --env BP_OPENTELEMETRY_ENABLED=true \
     --env BP_JVM_VERSION=17
 ```
@@ -21,8 +21,8 @@ You can also select a specific builder by passing the `--builder` flag:
 ```bash
 pack build applications/opentelemetry \
     --builder paketobuildpacks/ubuntu-resolute-builder \
-    --buildpack paketo-buildpacks/java \
-    --buildpack docker.io/paketobuildpacks/opentelemetry \
+    --buildpack docker.io/paketobuildpacks/java:latest \
+    --buildpack docker.io/paketobuildpacks/opentelemetry:latest \
     --env BP_OPENTELEMETRY_ENABLED=true \
     --env BP_JVM_VERSION=17
 ```

--- a/java/opentelemetry/README.md
+++ b/java/opentelemetry/README.md
@@ -6,6 +6,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 
 ```bash
 pack build applications/opentelemetry \
+    --builder paketobuildpacks/ubuntu-resolute-builder \
     --buildpack paketo-buildpacks/java \
     --buildpack docker.io/paketobuildpacks/opentelemetry \
     --env BP_OPENTELEMETRY_ENABLED=true \

--- a/java/opentelemetry/README.md
+++ b/java/opentelemetry/README.md
@@ -6,6 +6,20 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 
 ```bash
 pack build applications/opentelemetry \
+    --buildpack paketo-buildpacks/java \
+    --buildpack docker.io/paketobuildpacks/opentelemetry \
+    --env BP_OPENTELEMETRY_ENABLED=true \
+    --env BP_JVM_VERSION=17
+```
+
+> This sample's Gradle build pins a Java 17 toolchain, so `BP_JVM_VERSION=17` is required.
+
+### Advanced
+
+You can also select a specific builder by passing the `--builder` flag:
+
+```bash
+pack build applications/opentelemetry \
     --builder paketobuildpacks/ubuntu-resolute-builder \
     --buildpack paketo-buildpacks/java \
     --buildpack docker.io/paketobuildpacks/opentelemetry \

--- a/java/opentelemetry/build.gradle
+++ b/java/opentelemetry/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '4.0.+'
+  id 'org.springframework.boot' version '4.1.+'
   id 'io.spring.dependency-management' version '1.1.+'
 }
 

--- a/java/tools-build/README.md
+++ b/java/tools-build/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/clojure-tools-build
+pack build applications/clojure-tools-build --builder paketobuildpacks/ubuntu-resolute-builder
 ```
 
 ## Running

--- a/java/tools-build/README.md
+++ b/java/tools-build/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/clojure-tools-build
+```
+
+### Advanced
+
+You can also select a specific builder by passing the `--builder` flag:
+
+```bash
 pack build applications/clojure-tools-build --builder paketobuildpacks/ubuntu-resolute-builder
 ```
 

--- a/java/tools-build/deps.edn
+++ b/java/tools-build/deps.edn
@@ -1,9 +1,9 @@
 {:deps
-          {io.pedestal/pedestal.service {:mvn/version "0.5.10"}
-           io.pedestal/pedestal.route   {:mvn/version "0.5.10"}
-           io.pedestal/pedestal.jetty   {:mvn/version "0.5.10"}
-           org.clojure/data.json        {:mvn/version "2.4.0"}
-           org.slf4j/slf4j-simple       {:mvn/version "1.7.36"}}
+          {io.pedestal/pedestal.service {:mvn/version "0.7.2"}
+           io.pedestal/pedestal.route   {:mvn/version "0.7.2"}
+           io.pedestal/pedestal.jetty   {:mvn/version "0.7.2"}
+           org.clojure/data.json        {:mvn/version "2.5.2"}
+           org.slf4j/slf4j-simple       {:mvn/version "2.0.18"}}
  :paths ["src"]
- :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.8.1" :git/sha "7d40500"}}
+ :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.14"}}
                    :ns-default build}}}

--- a/java/war-spring/README.md
+++ b/java/war-spring/README.md
@@ -5,6 +5,14 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
+pack build applications/war --env BP_TOMCAT_VERSION=11
+```
+
+### Advanced
+
+You can also select a specific builder and control the JVM version by passing additional arguments:
+
+```bash
 pack build applications/war --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17 --env BP_TOMCAT_VERSION=11
 ```
 

--- a/java/war-spring/README.md
+++ b/java/war-spring/README.md
@@ -5,7 +5,7 @@ See [prerequisites](https://paketo.io/docs/howto/java/#prerequisites) of this sa
 ## Building
 
 ```bash
-pack build applications/war --env BP_JVM_VERSION=17 --env BP_TOMCAT_VERSION=10
+pack build applications/war --builder paketobuildpacks/ubuntu-resolute-builder --env BP_JVM_VERSION=17 --env BP_TOMCAT_VERSION=11
 ```
 
 ## Running

--- a/java/war-spring/pom.xml
+++ b/java/war-spring/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.2</version>
+		<version>4.1.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.paketo</groupId>
@@ -52,12 +52,9 @@
 				<configuration>
 					<image>
 						<env>
-							<BP_TOMCAT_VERSION>10</BP_TOMCAT_VERSION>
+							<BP_TOMCAT_VERSION>11</BP_TOMCAT_VERSION>
 						</env>
-						<builder>paketobuildpacks/builder-jammy-buildpackless-tiny</builder>
-						<buildpacks>
-							<buildpack>docker.io/paketobuildpacks/java:15.1.0</buildpack>
-						</buildpacks>
+						<builder>paketobuildpacks/ubuntu-resolute-builder:latest</builder>
 					</image>
 				</configuration>
 				<executions>

--- a/python/python_test.go
+++ b/python/python_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +52,12 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 		it.Before(func() {
 			pack = occam.NewPack().WithVerbose().WithNoColor()
 			docker = occam.NewDocker()
+
+			// The Ubuntu Resolute builder does not embed the Python buildpack, so it
+			// must be supplied explicitly at build time (see WithBuildpacks below).
+			if strings.Contains(builder, "resolute") {
+				Expect(docker.Pull.Execute("index.docker.io/paketobuildpacks/python")).To(Succeed())
+			}
 		})
 
 		context("detects a Python app", func() {
@@ -82,10 +89,13 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder).
-						Execute(name, source)
+						WithBuilder(builder)
+					if strings.Contains(builder, "resolute") {
+						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Miniconda")))
@@ -110,10 +120,13 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder).
-						Execute(name, source)
+						WithBuilder(builder)
+					if strings.Contains(builder, "resolute") {
+						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
@@ -139,10 +152,13 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder).
-						Execute(name, source)
+						WithBuilder(builder)
+					if strings.Contains(builder, "resolute") {
+						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
@@ -169,10 +185,13 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder).
-						Execute(name, source)
+						WithBuilder(builder)
+					if strings.Contains(builder, "resolute") {
+						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
@@ -199,10 +218,13 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder).
-						Execute(name, source)
+						WithBuilder(builder)
+					if strings.Contains(builder, "resolute") {
+						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
@@ -282,10 +304,13 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					image, logs, err = pack.Build.
+					build := pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder).
-						Execute(name, source)
+						WithBuilder(builder)
+					if strings.Contains(builder, "resolute") {
+						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
+					}
+					image, logs, err = build.Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))

--- a/python/python_test.go
+++ b/python/python_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -52,12 +51,6 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 		it.Before(func() {
 			pack = occam.NewPack().WithVerbose().WithNoColor()
 			docker = occam.NewDocker()
-
-			// The Ubuntu Resolute builder does not embed the Python buildpack, so it
-			// must be supplied explicitly at build time (see WithBuildpacks below).
-			if !strings.Contains(builder, "jammy") {
-				Expect(docker.Pull.Execute("index.docker.io/paketobuildpacks/python")).To(Succeed())
-			}
 		})
 
 		context("detects a Python app", func() {
@@ -89,13 +82,10 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					build := pack.Build.
+					image, logs, err = pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder)
-					if !strings.Contains(builder, "jammy") {
-						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
-					}
-					image, logs, err = build.Execute(name, source)
+						WithBuilder(builder).
+						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Miniconda")))
@@ -120,13 +110,10 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					build := pack.Build.
+					image, logs, err = pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder)
-					if !strings.Contains(builder, "jammy") {
-						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
-					}
-					image, logs, err = build.Execute(name, source)
+						WithBuilder(builder).
+						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
@@ -152,13 +139,10 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					build := pack.Build.
+					image, logs, err = pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder)
-					if !strings.Contains(builder, "jammy") {
-						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
-					}
-					image, logs, err = build.Execute(name, source)
+						WithBuilder(builder).
+						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
@@ -185,13 +169,10 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					build := pack.Build.
+					image, logs, err = pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder)
-					if !strings.Contains(builder, "jammy") {
-						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
-					}
-					image, logs, err = build.Execute(name, source)
+						WithBuilder(builder).
+						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
@@ -218,13 +199,10 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					build := pack.Build.
+					image, logs, err = pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder)
-					if !strings.Contains(builder, "jammy") {
-						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
-					}
-					image, logs, err = build.Execute(name, source)
+						WithBuilder(builder).
+						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))
@@ -304,13 +282,10 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					var logs fmt.Stringer
-					build := pack.Build.
+					image, logs, err = pack.Build.
 						WithPullPolicy("never").
-						WithBuilder(builder)
-					if !strings.Contains(builder, "jammy") {
-						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
-					}
-					image, logs, err = build.Execute(name, source)
+						WithBuilder(builder).
+						Execute(name, source)
 					Expect(err).ToNot(HaveOccurred(), logs.String)
 
 					Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for CPython")))

--- a/python/python_test.go
+++ b/python/python_test.go
@@ -55,7 +55,7 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 
 			// The Ubuntu Resolute builder does not embed the Python buildpack, so it
 			// must be supplied explicitly at build time (see WithBuildpacks below).
-			if strings.Contains(builder, "resolute") {
+			if !strings.Contains(builder, "jammy") {
 				Expect(docker.Pull.Execute("index.docker.io/paketobuildpacks/python")).To(Succeed())
 			}
 		})
@@ -92,7 +92,7 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					build := pack.Build.
 						WithPullPolicy("never").
 						WithBuilder(builder)
-					if strings.Contains(builder, "resolute") {
+					if !strings.Contains(builder, "jammy") {
 						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
 					}
 					image, logs, err = build.Execute(name, source)
@@ -123,7 +123,7 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					build := pack.Build.
 						WithPullPolicy("never").
 						WithBuilder(builder)
-					if strings.Contains(builder, "resolute") {
+					if !strings.Contains(builder, "jammy") {
 						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
 					}
 					image, logs, err = build.Execute(name, source)
@@ -155,7 +155,7 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					build := pack.Build.
 						WithPullPolicy("never").
 						WithBuilder(builder)
-					if strings.Contains(builder, "resolute") {
+					if !strings.Contains(builder, "jammy") {
 						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
 					}
 					image, logs, err = build.Execute(name, source)
@@ -188,7 +188,7 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					build := pack.Build.
 						WithPullPolicy("never").
 						WithBuilder(builder)
-					if strings.Contains(builder, "resolute") {
+					if !strings.Contains(builder, "jammy") {
 						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
 					}
 					image, logs, err = build.Execute(name, source)
@@ -221,7 +221,7 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					build := pack.Build.
 						WithPullPolicy("never").
 						WithBuilder(builder)
-					if strings.Contains(builder, "resolute") {
+					if !strings.Contains(builder, "jammy") {
 						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
 					}
 					image, logs, err = build.Execute(name, source)
@@ -307,7 +307,7 @@ func testPythonWithBuilder(builder string) func(*testing.T, spec.G, spec.S) {
 					build := pack.Build.
 						WithPullPolicy("never").
 						WithBuilder(builder)
-					if strings.Contains(builder, "resolute") {
+					if !strings.Contains(builder, "jammy") {
 						build = build.WithBuildpacks("index.docker.io/paketobuildpacks/python")
 					}
 					image, logs, err = build.Execute(name, source)


### PR DESCRIPTION
* upgrade dependencies,
* update configurations.
* also some python test too

_I used AI to help me create this PR, but I verified and tested the changes_

## Summary
Migrate Java samples to the Ubuntu Resolute builder + refresh dependencies

Moves the Java samples onto paketobuildpacks/ubuntu-resolute-builder, bumps runtimes to current releases, and updates CI accordingly.

### Builder

- All java/** samples now build with paketobuildpacks/ubuntu-resolute-builder (READMEs + embedded bootBuildImage/build-image config in poms and Gradle files).
- Native-image samples use the resolute builder with the ubuntu-resolute-run-tiny run image (the tiny builder no longer exists).

### Dependency upgrades (all verified building)

- Spring Boot → 4.1.0 (Maven & Gradle); war-spring also 3.3.2 → 4.1.0, Tomcat 10 → 11.
- Kotlin sample → Spring Boot 4.1 + Kotlin 2.2.
- Quarkus → 3.38.0; GraalVM native Gradle plugin → 1.1.
- Clojure (leiningen, deps, tools-build): Pedestal 0.5.10 → 0.7.2, Clojure 1.11.1 → 1.12.5, slf4j 1.7 → 2.0.18, logback 1.2 → 1.5.38, data.json 2.4 → 2.5.2, tools.build 0.8.1 → 
0.10.14.
- pipenv sample: unpinned Flask (was ==2.0.2) and regenerated Pipfile.lock (now Flask 3.1.3) — fixes a pre-existing pipenv install --deploy failure.

### CI

- test-pull-request-java.yml: all Java samples use the resolute builder.
- test-all-samples.yml: per-suite builder selection — resolute for java/**, nodejs, procfile, go, python, ca-certificates; jammy-full retained for dotnet-core, web-servers,
ruby, php (no resolute-stack binaries published upstream yet).
- go/python smoke tests supply their language buildpack explicitly when running on resolute (the builder doesn't bundle them); no change to the existing jammy runs.

### Notes

- dotnet-core, web-servers (httpd/nginx), ruby, php stay on jammy-full until resolute-stack dependencies are published.
- java/deps and java/tools-build build on resolute on amd64 (CI); they can't be built on arm64 with any builder yet, since the Clojure Tools buildpack's Clojure CLI is published
amd64-only.



## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
